### PR TITLE
DDCE-6953 -Updated BootstrapVersion, MongoVersion & sbt-plugin versions

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,9 +2,9 @@ import sbt.*
 
 object AppDependencies {
 
-  private val mongoHmrcVersion = "2.6.0"
+  private val mongoHmrcVersion = "2.7.0"
 
-  private val bootstrapVersion = "9.11.0"
+  private val bootstrapVersion = "9.18.0"
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % mongoHmrcVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,7 +18,7 @@ object AppDependencies {
     "uk.gov.hmrc"          %% "bootstrap-test-play-30"  % bootstrapVersion,
     "uk.gov.hmrc.mongo"    %% "hmrc-mongo-test-play-30" % mongoHmrcVersion,
     "org.scalatestplus"    %% "scalacheck-1-17"         % "3.2.18.0",
-    "org.jsoup"             % "jsoup"                   % "1.20.1",
+    "org.jsoup"             % "jsoup"                   % "1.21.1",
     "io.github.wolfendale" %% "scalacheck-gen-regexp"   % "1.1.0"
   ).map(_ % Test)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"         % "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework"   % "sbt-plugin"            % "3.0.7")
+addSbtPlugin("org.playframework"   % "sbt-plugin"            % "3.0.8")
 addSbtPlugin("org.scalastyle"      % "scalastyle-sbt-plugin" % "1.0.0" exclude ("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("org.scoverage"       % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("io.github.irundaia"  % "sbt-sassify"           % "1.5.2")


### PR DESCRIPTION
DDCE-6953 - Updated BootstrapVersion, MongoVersion & sbt-plugin to 9.18.0 , 2.7.0 & 3.0.8 respectively for register-estate-agent-details-frontend.
<img width="958" height="561" alt="DDCE-6953 - Local Execution Result -register-estate-agent-details-frontend" src="https://github.com/user-attachments/assets/12070756-f74d-4c20-8ced-f791e6994b6f" />

